### PR TITLE
Fix GetRolesAsync exception thrown when no user roles are found.

### DIFF
--- a/src/Redis.OM.Identity/Redis.OM.Identity.csproj
+++ b/src/Redis.OM.Identity/Redis.OM.Identity.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>Redis OM Identity</Title>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>Rabea Altaradeh</Authors>
     <Company>Inab Technologies</Company>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Redis.OM.Identity/UserStore.cs
+++ b/src/Redis.OM.Identity/UserStore.cs
@@ -329,8 +329,11 @@ public class UserStore<TUser, TRole, [DynamicallyAccessedMembers(DynamicallyAcce
 
 
         var userRoles = UserRoles.Where(x => x.UserId == user.Id).Select(x => x.RoleId).ToList();
-        var roles = Roles.Where(x => userRoles.Contains(x.Id)).ToList();
-        return await Task.FromResult<IList<string>>(roles.Where(x => x.Name != null).Select(z => z.Name!).ToList());
+        if (userRoles.Count > 0) {
+            var roles = Roles.Where(x => userRoles.Contains(x.Id)).ToList();
+            return await Task.FromResult<IList<string>>(roles.Where(x => x.Name != null).Select(z => z.Name!).ToList());
+        }
+        return await Task.FromResult<IList<string>>(Array.Empty<string>());
     }
 
     /// <summary>


### PR DESCRIPTION
Problem:
When attempting to login without any user roles defined in Redis.OM.Identity, the GetRolesAsync method throws an exception. This occurs because the method attempts to perform an FT.SEARCH command in Redis with no IDs, which is not valid and results in an error. This issue affects users trying to login with no roles assigned, leading to a poor user experience and potential security concerns as the login process is interrupted.

Solution:
This PR addresses the issue by adding a check for empty user roles before attempting to retrieve roles from Redis. If no user roles are found, the method now returns an empty list of strings, bypassing the problematic search query and preventing the exception from being thrown. This change ensures that the login process can proceed smoothly, even for users without any roles.

Changes Made:
Added a conditional check in GetRolesAsync to return an empty list if no user roles are identified.
Ensured that the rest of the method's logic is only executed when there are user roles to process, avoiding unnecessary operations and potential errors.

Impact:
This fix improves the stability and reliability of the login process in applications using Redis.OM.Identity, particularly enhancing user experience for scenarios where roles may not be initially assigned. It also prevents the application from entering an error state due to an unhandled exception, ensuring smoother operation and reducing potential security risks associated with login failures.

P.S. I also incremented the package version to reflect the minor change.